### PR TITLE
More specific statement about $LATEST version in Lambda

### DIFF
--- a/doc_source/lambda-edge-edit-function.md
+++ b/doc_source/lambda-edge-edit-function.md
@@ -4,7 +4,7 @@ When you want to edit a Lambda function, note the following:
 + The original version is labeled $LATEST\.
 + You can edit only the $LATEST version\.
 + Each time you edit the $LATEST version, you must publish a new numbered version\.
-+ You can't create triggers for $LATEST\.
++ You can't create Cloudfront triggers for $LATEST\.
 + When you publish a new version of a function, Lambda doesn't automatically copy triggers from the previous version to the new version\. You must reproduce the triggers for the new version\. 
 + When you add a trigger for a CloudFront event to a function, if there's already a trigger for the same distribution, cache behavior, and event for an earlier version of the same function, Lambda deletes the trigger from the earlier version\.
 + After you make updates to a CloudFront distribution, like adding triggers, you must wait for the changes to propagate to edge locations before the functions you've specified in the triggers will work\.<a name="lambda-edge-edit-function-procedure"></a>


### PR DESCRIPTION
Modifying the statement "You can't create triggers for $LATEST" to "You can't create Cloudfront triggers for $LATEST" as it is possible to create triggers except Cloudfront for $LATEST.

https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-edit-function.html

*Issue #, if available:*

*Description of changes:*
As it is possible to create triggers for the $LATEST version of a Lambda function, the statement "You can't create triggers for $LATEST" can be misleading, it would be more appropriate to state it as "You can't create Cloudfront triggers for $LATEST"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
