### PR TITLE
Add note for AWS Config

### DIFF
--- a/TrackingChanges.md
+++ b/TrackingChanges.md
@@ -2,6 +2,9 @@
 
 You can use AWS Config to record configuration changes for CloudFront distribution settings changes\. For example, you can capture changes to distribution states, price classes, origins, geo restriction settings, and Lambda@Edge configurations\. 
 
+**Note**  
+AWS Config does not record key–value tags for CloudFront distribution and CloudFront streaming distribution.
+
 ## Set Up AWS Config with CloudFront<a name="TrackingChangesSettings"></a>
 
 When you set up AWS Config, you can choose to record all supported AWS resources, or you can specify only certain resources to record configuration changes for, such as just recording changes for CloudFront\. To see the specific resources supported for CloudFront, see the list of [ Supported AWS Resource Types](http://docs.aws.amazon.com/config/latest/developerguide/resource-config-reference.html#supported-resources) in the *AWS Config Developer Guide*\. 


### PR DESCRIPTION
*Description of changes:*
Add note for AWS Config that tag/values are not supported yet. I think it make sense to have this hint on both locations.
See https://docs.aws.amazon.com/config/latest/developerguide/config-item-table.html Notes 2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
