### PR TITLE
Update status code limits

### DIFF
--- a/doc_source/lambda-requirements-limits.md
+++ b/doc_source/lambda-requirements-limits.md
@@ -117,7 +117,7 @@ For more information, see the following examples:
 
 ## HTTP Status Codes<a name="lambda-requirements-http-status-codes"></a>
 
-CloudFront doesn't execute Lambda functions for viewer response events if the origin returns HTTP status code 400 or higher\. 
+CloudFront doesn't execute Lambda functions for viewer response events if the origin returns HTTP status code 400 or higher\. Nor is it possible to modify the http status code from a viewer response event for a successful request.
 
 You can, however, execute Lambda functions for *origin* response errors, including HTTP status codes 4xx and 5xx\. For more information, see [Updating HTTP Responses in Origin\-Response Triggers](lambda-updating-http-responses.md)\.
 


### PR DESCRIPTION
Updates the info on status code limits to indicate that viewer response triggers cannot be used to modify the http status code at all (previous docs indicated that this limit only existed for failure codes).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
