### PR TITLE
Added File::Slurp to the Cloudfront signed URL perl example

### DIFF
--- a/doc_source/CreateURLPerl.md
+++ b/doc_source/CreateURLPerl.md
@@ -183,6 +183,7 @@ use warnings;
 # run perl -MCPAN -e "install <module>" to get them.
 # The openssl command line will also need to be in your $PATH.
 use File::Temp qw/tempfile/;
+use File::Slurp;
 use Getopt::Long;
 use IPC::Open2;
 use MIME::Base64 qw(encode_base64 decode_base64);


### PR DESCRIPTION
The example cfsign.pl script would fail with `Undefined subroutine &main::write_file called at cfsign.pl line 366.`. Adding the File::Slurp module adds the write_file function, and allows the script to create signed URLs.

This was noticed on macOS 10.14.4 with Perl v5.18.2

*Issue #, if available:*

*Description of changes:* Added `use File::Slurp;` to the example perl script for creating signed URLs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
