### PR TITLE
Stop processing after callback executed

### DIFF
--- a/doc_source/lambda-examples.md
+++ b/doc_source/lambda-examples.md
@@ -676,6 +676,7 @@ exports.handler = (event, context, callback) => {
     const parsedCookies = parseCookies(headers);
     if (parsedCookies && parsedCookies['session-id']) {
         callback(null, request);
+	return;
     }
 
     /* URI encode the original request to be sent as redirect_url in query params */


### PR DESCRIPTION
This fixes a bug causing processing to resume after the `callback`, causing irrelevant operations and conflicting `callback` execution

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
