### PR TITLE
Use correct ISO code GB for United Kingdom in example lambda

### DIFF
--- a/doc_source/lambda-examples.md
+++ b/doc_source/lambda-examples.md
@@ -1355,7 +1355,7 @@ exports.handler = (event, context, callback) => {
      
   if (request.headers['cloudfront-viewer-country']) {
          const countryCode = request.headers['cloudfront-viewer-country'][0].value;
-         if (countryCode === 'UK' || countryCode === 'DE' || countryCode === 'IE' ) {
+         if (countryCode === 'GB' || countryCode === 'DE' || countryCode === 'IE' ) {
              const domainName = 'eu.example.com';
              request.origin.custom.domainName = domainName;
              request.headers['host'] = [{key: 'host', value: domainName}];
@@ -1376,7 +1376,7 @@ exports.handler = (event, context, callback) => {
      viewerCountry = request['headers'].get('cloudfront-viewer-country')
      if viewerCountry:
          countryCode = viewerCountry[0]['value']
-         if countryCode == 'UK' or countryCode == 'DE' or countryCode == 'IE':
+         if countryCode == 'GB' or countryCode == 'DE' or countryCode == 'IE':
              domainName = 'eu.example.com'
              request['origin']['custom']['domainName'] = domainName
              request['headers']['host'] = [{'key': 'host', 'value': domainName}]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changed example lambdas to use GB instead of UK. UK is reserved for the United Kingdom, but GB is the official ISO code.

https://en.wikipedia.org/wiki/ISO_3166-2:GB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
