### PR TITLE
Add note on IncludeBody for lambda@edge examples

### DIFF
--- a/doc_source/lambda-examples.md
+++ b/doc_source/lambda-examples.md
@@ -1520,6 +1520,8 @@ exports.handler = (event, context, callback) => {
 
 The examples in this section illustrate how you can use Lambda@Edge to work with POST requests\.
 
+For these examples to work, the [LambdaFunctionAssociation](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_LambdaFunctionAssociation.html) that is part of the Cloudfront distribution must have `IncludeBody` enabled.
+
 **Topics**
 + [Example: Using a Request Trigger to Read an HTML Form](#lambda-examples-access-request-body-examples-read)
 + [Example: Using a Request Trigger to Modify an HTML Form](#lambda-examples-access-request-body-examples-replace)

--- a/doc_source/lambda-examples.md
+++ b/doc_source/lambda-examples.md
@@ -1520,7 +1520,10 @@ exports.handler = (event, context, callback) => {
 
 The examples in this section illustrate how you can use Lambda@Edge to work with POST requests\.
 
-For these examples to work, the [LambdaFunctionAssociation](https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_LambdaFunctionAssociation.html) that is part of the Cloudfront distribution must have `IncludeBody` enabled.
+**Note**  
+To use these examples, you must enable the *include body* option in the distribution’s Lambda function association\. It is not enabled by default\.  
+To enable this setting in the CloudFront console, select the check box for **Include Body** in the **Lambda Function Association**\.
+To enable this setting in the CloudFront API or with AWS CloudFormation, set the `IncludeBody` field to `true` in `LambdaFunctionAssociation`\.
 
 **Topics**
 + [Example: Using a Request Trigger to Read an HTML Form](#lambda-examples-access-request-body-examples-read)


### PR DESCRIPTION
The lambda@edge examples that access the request body don't work unless IncludeBody has been enabled. This is an important detail because it is disabled by default everywhere and the CDK doesn't even allow setting it to true, so it's quite easy for users like myself to get confused when the examples just don't work.

This PR just documents that required pre-condition.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
