### PR TITLE
Edit typo in second header

### DIFF
--- a/doc_source/CreateURL_PHP.md
+++ b/doc_source/CreateURL_PHP.md
@@ -225,7 +225,7 @@ $custom_policy_stream_name = get_custom_policy_stream_name($video_path, $private
 
     <div id='canned'>The canned policy video will be here</div>
 
-    <h2>Canned Policy</h2>
+    <h2>Custom Policy</h2>
     <h3>Expires at <?= gmdate('Y-m-d H:i:s T', $expires) ?> only viewable by IP <?= $client_ip ?></h3>
     <div id='custom'>The custom policy video will be here</div>
 


### PR DESCRIPTION
Second "Canned Policy" header should read "Custom Policy"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
