### PR TITLE
Update lambda-examples.md

### DIFF
--- a/doc_source/lambda-examples.md
+++ b/doc_source/lambda-examples.md
@@ -543,8 +543,8 @@ function parseCookies(headers) {
     if (headers.cookie) {
         headers.cookie[0].value.split(';').forEach((cookie) => {
             if (cookie) {
-                const parts = cookie.split('=');
-                parsedCookie[parts[0].trim()] = parts[1].trim();
+                const split = cookie.indexOf('=');
+                parsedCookie[cookie.substring(0, split).trim()] = cookie.substring(split+1).trim();
             }
         });
     }
@@ -594,7 +594,7 @@ def parseCookies(headers):
     if headers.get('cookie'):
         for cookie in headers['cookie'][0]['value'].split(';'):
             if cookie:
-                parts = cookie.split('=')
+                parts = cookie.split('=', 1)
                 parsedCookie[parts[0].strip()] = parts[1].strip()
     return parsedCookie
 


### PR DESCRIPTION
Found a small bug in the parseCookies() function. If the cookie contents is a base64 encoded string, and contains any trailing '=' signs, those are cut off by using the split function. This results in a cookie with "test=dGVzdDp0ZXN0MQ==" being parsed as `cookies['test'] = 'dGVzdDp0ZXN0MQ'` instead of `cookies['test'] = 'dGVzdDp0ZXN0MQ=='`

*Issue #, if available:*

*Description of changes:*
For Python this can be easily resolved by adding a limit 1 to the split function. Nodejs requires a different method, as doing a `cookie.split('=', 1)` results in the trailing '=' signs being removed from the string.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
