### PR TITLE
Remember to capitalise the "F" in "CloudFront"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Amazon Cloudfront Developer Guide
+## Amazon CloudFront Developer Guide
 
 The open source version of the Amazon CloudFront documentation.
 

--- a/doc_source/field-level-encryption.md
+++ b/doc_source/field-level-encryption.md
@@ -218,7 +218,7 @@ public class DecryptExample {
     // In your own code, use the Key name that you specified when you added your public key to CloudFront. This sample 
     // uses 'DEMOKEY' for the Key name.
     private static final String KEY_NAME = "DEMOKEY";
-    // Cloudfront uses this algorithm when encrypting data.
+    // CloudFront uses this algorithm when encrypting data.
     private static final String ALGORITHM = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding";
  
     public static void main(final String[] args) throws Exception {


### PR DESCRIPTION
*Issue #, if available:* none.

*Description of changes:* The name "CloudFront" usually has a capitalised "F", but I found two places where it was lowercase. This command finds them:

```
grep -rnI 'Cloudfront' .
```

and I fixed them by hand, since there were only two instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
