### PR TITLE
Updated references to 'Comodo' to 'Sectigo' - the CA was rebranded.

### DIFF
--- a/doc_source/cnames-and-https-limits.md
+++ b/doc_source/cnames-and-https-limits.md
@@ -20,7 +20,7 @@ If you're using a third\-party CA and you want to use the same certificate with 
 If you're using certificates provided by ACM, you can't configure CloudFront to use certificates that were created by a different AWS account\.
 
 **Using the Same Certificate for CloudFront and for Other AWS Services \(IAM Certificate Store Only\) **  
-If you bought a certificate from a trusted certificate authority such as Comodo, DigiCert, or Symantec, you can use the same certificate for CloudFront and for other AWS services\. If you're importing the certificate into ACM, you need to import it only once to use it for multiple AWS services\.  
+If you bought a certificate from a trusted certificate authority such as Sectigo, DigiCert, or Symantec, you can use the same certificate for CloudFront and for other AWS services\. If you're importing the certificate into ACM, you need to import it only once to use it for multiple AWS services\.  
 If you're using certificates provided by ACM, the certificates are stored in ACM\.
 
 **Using the Same Certificate for Multiple CloudFront Distributions**  

--- a/doc_source/cnames-and-https-requirements.md
+++ b/doc_source/cnames-and-https-requirements.md
@@ -22,10 +22,10 @@ The requirements for SSL/TLS certificates are described in this topic\. They app
 ## Certificate Issuer<a name="https-requirements-certificate-issuer"></a>
 
 The certificate issuer you must use depends on whether you want to require HTTPS between viewers and CloudFront or between CloudFront and your origin:
-+ **HTTPS between viewers and CloudFront** – You can use a certificate that was issued by a trusted certificate authority \(CA\) such as Comodo, DigiCert, or Symantec, or you can use a certificate provided by AWS Certificate Manager \(ACM\)\.
++ **HTTPS between viewers and CloudFront** – You can use a certificate that was issued by a trusted certificate authority \(CA\) such as Sectigo, DigiCert, or Symantec, or you can use a certificate provided by AWS Certificate Manager \(ACM\)\.
 **Important**  
 If you want to use an alternate domain name with your CloudFront distribution, you must verify to CloudFront that you have authorized rights to use the alternate domain name\. To do this, you must attach a valid certificate to your distribution, and make sure that the certificate comes from a trusted CA that is listed on the [ Mozilla Included CA Certificate List](http://www.mozilla.org/en-US/about/governance/policies/security-group/certs/included/)\. CloudFront does not allow you to use a self\-signed certificate to verify your authorized rights to use an alternate domain name\.
-+ **HTTPS between CloudFront and a custom origin** – If the origin is *not* an Elastic Load Balancing \(ELB\) load balancer, such as Amazon EC2, the certificate must be issued by a trusted CA such as Comodo, DigiCert, or Symantec\. If your origin is an ELB load balancer, you can also use a certificate provided by ACM\.
++ **HTTPS between CloudFront and a custom origin** – If the origin is *not* an Elastic Load Balancing \(ELB\) load balancer, such as Amazon EC2, the certificate must be issued by a trusted CA such as Sectigo, DigiCert, or Symantec\. If your origin is an ELB load balancer, you can also use a certificate provided by ACM\.
 **Important**  
 When CloudFront uses HTTPS to communicate with your origin, CloudFront verifies that the certificate was issued by a trusted CA\. CloudFront supports the same certificate authorities as Mozilla; for the current list, see [ Mozilla Included CA Certificate List](https://wiki.mozilla.org/CA/Included_Certificates)\. You cannot use a self\-signed certificate for HTTPS communication between CloudFront and your origin\.
 

--- a/doc_source/using-https-cloudfront-to-custom-origin.md
+++ b/doc_source/using-https-cloudfront-to-custom-origin.md
@@ -56,7 +56,7 @@ Choose the **Origin SSL Protocols** for the applicable origins in your distribut
 
 You can use an SSL/TLS certificate from the following sources on your custom origin:
 + If your origin is an Elastic Load Balancing load balancer, you can use a certificate provided by AWS Certificate Manager \(ACM\)\. You also can use a certificate that is signed by a trusted third\-party certificate authority and imported into ACM\.
-+ For origins other than Elastic Load Balancing load balancers, you must use a certificate that is signed by a trusted third\-party certificate authority \(CA\), for example, Comodo, DigiCert, or Symantec\.
++ For origins other than Elastic Load Balancing load balancers, you must use a certificate that is signed by a trusted third\-party certificate authority \(CA\), for example, Sectigo, DigiCert, or Symantec\.
 
 When CloudFront uses HTTPS to communicate with your origin, CloudFront verifies that the certificate was issued by a trusted certificate authority\. CloudFront supports the same certificate authorities that Mozilla does\. For the current list, see [Mozilla Included CA Certificate List](https://wiki.mozilla.org/CA/Included_Certificates)\. You can't use a self\-signed certificate for HTTPS communication between CloudFront and your origin\.
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
'Comodo' or 'Comodo CA' was rebranded into Sectigo in 2018.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
