### PR TITLE
CloudWatch Metrics: Fix names, add Limit Exceeded

### DIFF
--- a/doc_source/programming-cloudwatch-metrics.md
+++ b/doc_source/programming-cloudwatch-metrics.md
@@ -134,13 +134,19 @@ The number of times the function was started \(invoked\) in a given time period\
 
 **Validation errors**  
 The number of validation errors produced by the function in a given time period\. Validation errors occur when the function runs successfully but returns invalid data \(an invalid event object\)\.  
-+ Metric name: `ValidationErrors`
++ Metric name: `LambdaValidationError`
 + Valid statistic: `Sum`
 + Unit: `None`
 
 **Execution errors**  
 The number of execution errors that occurred in a given time period\. Execution errors occur when the function fails to complete successfully\.  
-+ Metric name: `ExecutionErrors`
++ Metric name: `LambdaExecutionError`
++ Valid statistic: `Sum`
++ Unit: `None`
+
+**Limit exceeded errors**  
+The number of execution errors that occured because limit was exceeded\. This can happen due to concurrent execution quotas, invocation frequency quotas, or a timeout quota\. See also [Lambda Limit Exceeded](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/http-503-lambda-limit-execeeded-error.html)\.  
++ Metric name: `LambdaLimitExceededErrors`
 + Valid statistic: `Sum`
 + Unit: `None`
 


### PR DESCRIPTION
*Description of changes:*
- Changed ValidationErrors -> LambdaValidationError
- Changed ExecutionErrors -> LambdaExecutionError
- Added LambdaLimitExceededErrors with a best guess of when it can occur.

I found these by browsing the requests that are made by [CloudFront -> Monitoring](https://console.aws.amazon.com/cloudfront/v2/home?#/monitoring). Notably, none of these are visible when browsing [CloudWatch -> Metrics](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2:graph=~()).
This means I can't easily verify their names. I am also just guessing on when LambdaLimitExceededErrors actually occurs.

Before this is merged, I would appreciate if an AWS engineer verified the changed names and also the other names in the document. I cannot vouch for their correctness.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
