### PR TITLE
[cf functions docs] Fix distributionID -> distributionId

### DIFF
--- a/doc_source/functions-event-structure.md
+++ b/doc_source/functions-event-structure.md
@@ -42,7 +42,7 @@ The `context` object contains contextual information about the event\. It includ
 **`distributionDomainName`**  
 The CloudFront domain name \(for example, d111111abcdef8\.cloudfront\.net\) of the distribution that’s associated with the event\.
 
-**`distributionID`**  
+**`distributionId`**  
 The ID of the distribution \(for example, EDFDVBD6EXAMPLE\) that’s associated with the event\.
 
 **`eventType`**  


### PR DESCRIPTION
```diff
- distributionID
+ distributionId
```

*Issue #, if available:*

*Description of changes:*

`distributionID` seems to be cased, slightly wrong. The example event object has the key `distributionId`. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
