### PR TITLE
Cache-control header don't need the ';'

### DIFF
--- a/doc_source/example-function-add-cache-control-header.md
+++ b/doc_source/example-function-add-cache-control-header.md
@@ -12,7 +12,7 @@ function handler(event) {
     var headers = response.headers;
 
     // Set the cache-control header
-    headers['cache-control'] = {value: 'public, max-age=63072000;'};
+    headers['cache-control'] = {value: 'public, max-age=63072000'};
 
     // Return response to viewers
     return response;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This function is updated in the aws-samples repo. But the changes do not update on the document page.
Since cache-control does not need ";", and the cache is not enabled if the ";" is there.

Ref:
https://github.com/aws-samples/amazon-cloudfront-functions/blob/main/add-cache-control-header/index.js

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
