### PR TITLE
Remove the `;` in `Cache-Control` header

### DIFF
--- a/doc_source/example-function-add-cache-control-header.md
+++ b/doc_source/example-function-add-cache-control-header.md
@@ -12,7 +12,7 @@ function handler(event) {
     var headers = response.headers;
 
     // Set the cache-control header
-    headers['cache-control'] = {value: 'public, max-age=63072000;'};
+    headers['cache-control'] = {value: 'public, max-age=63072000'};
 
     // Return response to viewers
     return response;


### PR DESCRIPTION
*Description of changes:*
Browser cache is not enable if the `;` is there. The original sample code repo had been updated too; please refer to [this commit](https://github.com/aws-samples/amazon-cloudfront-functions/commit/abeecde838b74b37bc8b510f69485a4e0c417d06)