### PR TITLE
fixing broken link for python signed url examples

### DIFF
--- a/doc_source/PrivateCFSignatureCodeAndExamples.md
+++ b/doc_source/PrivateCFSignatureCodeAndExamples.md
@@ -4,7 +4,7 @@ This section includes downloadable application examples that demonstrate how to 
 
 For example code in JavaScript \(Node\.js\), see [Creating Amazon CloudFront Signed URLs in Node\.js](http://aws.amazon.com/blogs/developer/creating-amazon-cloudfront-signed-urls-in-node-js/) on the AWS Developer Blog\.
 
-For example code in Python, see the [generate\_presigned\_url\(\) method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#CloudFront.Client.generate_presigned_url) in the *AWS SDK for Python \(Boto3\) API Reference* and [this example code](https://github.com/boto/boto3/blob/develop/boto3/examples/cloudfront.rst) in the Boto3 GitHub repository\.
+For example code in Python, see the [generate\_presigned\_url\(\) method](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/cloudfront.html#generate-a-signed-url-for-amazon-cloudfront) in the *AWS SDK for Python \(Boto3\) API Reference* and [this example code](https://github.com/boto/boto3/blob/develop/boto3/examples/cloudfront.rst) in the Boto3 GitHub repository\.
 
 **Topics**
 + [Create a URL signature using Perl](CreateURLPerl.md)


### PR DESCRIPTION
*Description of changes:*
A link to the CloudFront Boto3 docs doesn't go to the correct section of the page. This fixes the link so that it goes to the appropriate example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
